### PR TITLE
Заменяет ROOT_DIR_ на ROOT_DIR для единообразия

### DIFF
--- a/engine/Core/Template/Theme.php
+++ b/engine/Core/Template/Theme.php
@@ -17,7 +17,7 @@ class Theme
 
     public function __construct()
     {
-        $this->themePath = ROOT_DIR_ . '/content/themes/default/';
+        $this->themePath = ROOT_DIR . '/content/themes/default/';
         $this->themeUrl = '/content/themes/default/';
     }
 

--- a/engine/Core/Template/View.php
+++ b/engine/Core/Template/View.php
@@ -48,6 +48,6 @@ class View
             ? '/content/themes/default/'
             : '/View/';
 
-        return ROOT_DIR_ . $basePath . $template . '.php';
+        return ROOT_DIR . $basePath . $template . '.php';
     }
 }

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-define('ROOT_DIR_', __DIR__);
+define('ROOT_DIR', __DIR__);
 // Подключаем автозагрузчик Composer
 require __DIR__ . '/vendor/autoload.php';
 


### PR DESCRIPTION
- Заменяет использование ROOT_DIR_ на ROOT_DIR в соответствующих файлах.
- Приводит именование констант в соответствие со стандартами PSR-1/PSR-12, избегая лишних суффиксов (если они не требуются для предотвращения коллизий).
